### PR TITLE
Fixing predictive search: We need to covert only those articles that …

### DIFF
--- a/src/services/Content-Service.coffee
+++ b/src/services/Content-Service.coffee
@@ -100,10 +100,15 @@ class Content_Service
                          .folder_Create()
 
   map_Source_Files: ()=>
+    xml_File    = @.folder_Lib_UNO.path_Combine 'UNO.xml'
+    xml_Content = xml_File.file_Contents()
     'source_Files'.cache_Use ()=>
       data = {}
       for file in @.folder_Lib_UNO.files_Recursive(".xml")
         file_Key = file.file_Name_Without_Extension()
+        #Just converting articles in a view
+        if not xml_Content.contains(file_Key) && file_Key isnt 'UNO'
+          continue
         mapping =
           xml_File  : file.remove @.folder_Lib_UNO
           #checksum  : null


### PR DESCRIPTION
Fixing issue https://github.com/TeamMentor/TM_4_0_Design/issues/1111 : This PR fixes predictive search so that search is populated only with findings from imported/converted articles.
